### PR TITLE
Update BaseWebRTCSink to have optional dynamic resolution/framerate, support H265 Nvidia V4L2 encoder

### DIFF
--- a/net/webrtc/src/webrtcsink/imp.rs
+++ b/net/webrtc/src/webrtcsink/imp.rs
@@ -56,6 +56,7 @@ const DEFAULT_CONGESTION_CONTROL: WebRTCSinkCongestionControl = if cfg!(feature 
 } else {
     WebRTCSinkCongestionControl::Disabled
 };
+const DEFAULT_DO_DYNAMIC_DECIMATION: bool = true;
 const DEFAULT_DO_FEC: bool = true;
 const DEFAULT_DO_RETRANSMISSION: bool = true;
 const DEFAULT_DO_CLOCK_SIGNALLING: bool = false;
@@ -85,6 +86,7 @@ struct Settings {
     cc_info: CCInfo,
     do_fec: bool,
     do_retransmission: bool,
+    do_dynamic_decimation: bool,
     do_clock_signalling: bool,
     enable_data_channel_navigation: bool,
     meta: Option<gst::Structure>,
@@ -407,6 +409,7 @@ impl Default for Settings {
             },
             do_fec: DEFAULT_DO_FEC,
             do_retransmission: DEFAULT_DO_RETRANSMISSION,
+            do_dynamic_decimation: DEFAULT_DO_DYNAMIC_DECIMATION,
             do_clock_signalling: DEFAULT_DO_CLOCK_SIGNALLING,
             enable_data_channel_navigation: DEFAULT_ENABLE_DATA_CHANNEL_NAVIGATION,
             meta: None,
@@ -941,60 +944,73 @@ impl VideoEncoder {
             _ => return Err(WebRTCSinkError::BitrateNotSupported),
         }
 
-        let current_caps = self.filter.property::<gst::Caps>("caps");
-        let mut s = current_caps.structure(0).unwrap().to_owned();
-
-        // Hardcoded thresholds have been adapted from the values that shipped
-        // with the plugin to suit our needs.
-        //
-        // In the lowest quality mode, we still maintain 720p, but rely on downstream
-        // encoder's quantization to fit the bitrate budget.
-        if bitrate < 1_000_000 {
-            let height = 720i32.min(self.video_info.height() as i32);
-            let width = self.scale_height_round_2(height);
-
-            if self.halved_framerate.numer() != 0 {
-                s.set("framerate", self.halved_framerate);
-            }
-
-            s.set("height", height);
-            s.set("width", width);
-
-            self.mitigation_mode =
-                WebRTCSinkMitigationMode::DOWNSAMPLED | WebRTCSinkMitigationMode::DOWNSCALED;
-        } else if bitrate < 2_500_000 {
-            let height = 720i32.min(self.video_info.height() as i32);
-            let width = self.scale_height_round_2(height);
-
-            s.set("height", height);
-            s.set("width", width);
-            s.remove_field("framerate");
-
-            self.mitigation_mode = WebRTCSinkMitigationMode::DOWNSCALED;
-        } else {
-            s.remove_field("height");
-            s.remove_field("width");
-            s.remove_field("framerate");
-
-            self.mitigation_mode = WebRTCSinkMitigationMode::NONE;
-        }
-
-        let caps = gst::Caps::builder_full_with_any_features()
-            .structure(s)
-            .build();
-
-        if !caps.is_strictly_equal(&current_caps) {
-            gst::log!(
+        if element.property("do-dynamic-decimation") {
+            gst::trace!(
                 CAT,
                 obj = element,
-                "session {}: setting bitrate {} and caps {} on encoder {:?}",
-                self.session_id,
-                bitrate,
-                caps,
-                self.element
+                "doing dynamic resolution/framerate"
             );
+            let current_caps = self.filter.property::<gst::Caps>("caps");
+            let mut s = current_caps.structure(0).unwrap().to_owned();
 
-            self.filter.set_property("caps", caps);
+            // Hardcoded thresholds have been adapted from the values that shipped
+            // with the plugin to suit our needs.
+            //
+            // In the lowest quality mode, we still maintain 720p, but rely on downstream
+            // encoder's quantization to fit the bitrate budget.
+            if bitrate < 1_000_000 {
+                let height = 720i32.min(self.video_info.height() as i32);
+                let width = self.scale_height_round_2(height);
+
+                if self.halved_framerate.numer() != 0 {
+                    s.set("framerate", self.halved_framerate);
+                }
+
+                s.set("height", height);
+                s.set("width", width);
+
+                self.mitigation_mode =
+                    WebRTCSinkMitigationMode::DOWNSAMPLED | WebRTCSinkMitigationMode::DOWNSCALED;
+            } else if bitrate < 2_500_000 {
+                let height = 720i32.min(self.video_info.height() as i32);
+                let width = self.scale_height_round_2(height);
+
+                s.set("height", height);
+                s.set("width", width);
+                s.remove_field("framerate");
+
+                self.mitigation_mode = WebRTCSinkMitigationMode::DOWNSCALED;
+            } else {
+                s.remove_field("height");
+                s.remove_field("width");
+                s.remove_field("framerate");
+
+                self.mitigation_mode = WebRTCSinkMitigationMode::NONE;
+            }
+
+            let caps = gst::Caps::builder_full_with_any_features()
+                .structure(s)
+                .build();
+
+            if !caps.is_strictly_equal(&current_caps) {
+                gst::log!(
+                    CAT,
+                    obj = element,
+                    "session {}: setting bitrate {} and caps {} on encoder {:?}",
+                    self.session_id,
+                    bitrate,
+                    caps,
+                    self.element
+                );
+
+                self.filter.set_property("caps", caps);
+            }
+        } else {
+            gst::trace!(
+                CAT,
+                obj = element,
+                "not doing dynamic resolution/framerate"
+            );
         }
 
         Ok(())
@@ -3933,6 +3949,12 @@ impl ObjectImpl for BaseWebRTCSink {
                     .flags(glib::ParamFlags::READABLE | gst::PARAM_FLAG_MUTABLE_READY)
                     .blurb("The Signallable object to use to handle WebRTC Signalling")
                     .build(),
+                glib::ParamSpecBoolean::builder("do-dynamic-decimation")
+                    .nick("Dynamically decimate the framerate/resolution according to bitrate")
+                    .blurb("Whether the element's underlying encoder should dynamically adjust resolution/framerate according to target bitrate")
+                    .default_value(DEFAULT_DO_DYNAMIC_DECIMATION)
+                    .mutable_ready()
+                    .build(),
             ]
         });
 
@@ -4012,6 +4034,10 @@ impl ObjectImpl for BaseWebRTCSink {
                     .get::<WebRTCICETransportPolicy>()
                     .expect("type checked upstream");
             }
+            "do-dynamic-decimation" => {
+                let mut settings = self.settings.lock().unwrap();
+                settings.do_dynamic_decimation = value.get::<bool>().expect("type checked upstream");
+            }
             _ => unimplemented!(),
         }
     }
@@ -4076,6 +4102,10 @@ impl ObjectImpl for BaseWebRTCSink {
                 settings.ice_transport_policy.to_value()
             }
             "signaller" => self.settings.lock().unwrap().signaller.to_value(),
+            "do-dynamic-decimation" => {
+                let settings = self.settings.lock().unwrap();
+                settings.do_dynamic_decimation.to_value()
+            }
             _ => unimplemented!(),
         }
     }

--- a/net/webrtc/src/webrtcsink/imp.rs
+++ b/net/webrtc/src/webrtcsink/imp.rs
@@ -945,11 +945,6 @@ impl VideoEncoder {
         }
 
         if element.property("do-dynamic-decimation") {
-            gst::trace!(
-                CAT,
-                obj = element,
-                "doing dynamic resolution/framerate"
-            );
             let current_caps = self.filter.property::<gst::Caps>("caps");
             let mut s = current_caps.structure(0).unwrap().to_owned();
 
@@ -1005,12 +1000,6 @@ impl VideoEncoder {
 
                 self.filter.set_property("caps", caps);
             }
-        } else {
-            gst::trace!(
-                CAT,
-                obj = element,
-                "not doing dynamic resolution/framerate"
-            );
         }
 
         Ok(())

--- a/net/webrtc/src/webrtcsink/imp.rs
+++ b/net/webrtc/src/webrtcsink/imp.rs
@@ -626,7 +626,7 @@ fn configure_encoder(enc: &gst::Element, start_bitrate: u32) {
                 enc.set_property("keyframe-period", 2560u32);
                 enc.set_property_from_str("rate-control", "cbr");
             }
-            "nvv4l2h264enc" => {
+            "nvv4l2h264enc" | "nvv4l2h265enc" => {
                 enc.set_property("bitrate", start_bitrate);
                 enc.set_property_from_str("preset-level", "UltraFastPreset");
                 enc.set_property("maxperf-enable", true);
@@ -879,6 +879,7 @@ impl VideoEncoder {
                 | "vaapivp8enc"
                 | "qsvh264enc"
                 | "nvv4l2h264enc"
+                | "nvv4l2h265enc"
                 | "nvv4l2vp8enc"
                 | "nvv4l2vp9enc"
                 | "nvav1enc"
@@ -895,7 +896,7 @@ impl VideoEncoder {
             "av1enc" => (self.element.property::<u32>("target-bitrate") * 1000) as i32,
             "x264enc" | "nvh264enc" | "vaapih264enc" | "vaapivp8enc" | "qsvh264enc"
             | "nvav1enc" | "vpuenc_h264" => (self.element.property::<u32>("bitrate") * 1000) as i32,
-            "nvv4l2h264enc" | "nvv4l2vp8enc" | "nvv4l2vp9enc" | "rav1enc" | "nvv4l2av1enc" => {
+            "nvv4l2h264enc" | "nvv4l2h265enc" | "nvv4l2vp8enc" | "nvv4l2vp9enc" | "rav1enc" | "nvv4l2av1enc" => {
                 (self.element.property::<u32>("bitrate")) as i32
             }
             _ => return Err(WebRTCSinkError::BitrateNotSupported),
@@ -933,7 +934,7 @@ impl VideoEncoder {
                 self.element
                     .set_property("bitrate", (bitrate / 1000) as u32);
             }
-            "nvv4l2h264enc" | "nvv4l2vp8enc" | "nvv4l2vp9enc" | "nvv4l2av1enc" => {
+            "nvv4l2h264enc" | "nvv4l2h265enc" | "nvv4l2vp8enc" | "nvv4l2vp9enc" | "nvv4l2av1enc" => {
                 self.element.set_property("bitrate", bitrate as u32)
             }
             "rav1enc" => self.element.set_property("bitrate", bitrate),


### PR DESCRIPTION
# Background
The built-in functionality of the `BaseWebRTCSink` is to change its resolution and framerate according to the congestion controller's target bitrate. We had previously tweaked the default encoding ladder such that the resolution would never drop below 1280x720, but the framerate still _could_ be decimated in low bandwidth cases.

However, since we are using a variable bitrate encode - this is part of the Georgia vehicle's latest config - we empirically tested that decimating the framerate was actually detrimental to the stream experience. The variable bitrate & wide quantization range made the stream tolerant at 20FPS, even though the congestion controller was reporting a "low" available bandwidth.

# Description
This PR adds a property on the `webrtcsink` (from the `BaseWebRTCSink` class) called `do_dynamic_decimation` which, if enabled, performs the aforementioned framerate/resolution changes according to the target bitrate. If the property is disabled, then it will only set the target bitrate on the encoder, and not change the source framerate/resolution.

By default, the property is **enabled** - which is the functionality of the plugin before this change - but a followup PR in `monorail` will make the (parent) pipeline set this property according to the vehicle's service regsitry (which will be disable it).

This PR also enables the `webrtcsink` to support `nvv4l2h265enc` (Nvidia's V4L2 H265 encoder) as part of its encoder set.

# Verification
When the property is enabled:
```
[2025-05-30T20:42:40Z INFO  gst::webrtcsink] <basewebrtcsink0> doing dynamic resolution/framerate: br 2133043
...
[2025-05-30T20:42:41Z INFO  gst::webrtcsink] <basewebrtcsink0> doing dynamic resolution/framerate: br 2138187
...
[2025-05-30T20:42:43Z INFO  gst::webrtcsink] <basewebrtcsink0> doing dynamic resolution/framerate: br 2159859
...
[2025-05-30T20:42:44Z INFO  gst::webrtcsink] <basewebrtcsink0> doing dynamic resolution/framerate: br 1994372
...
[2025-05-30T20:42:45Z INFO  gst::webrtcsink] <basewebrtcsink0> doing dynamic resolution/framerate: br 1443605
...
[2025-05-30T20:42:46Z INFO  gst::webrtcsink] <basewebrtcsink0> doing dynamic resolution/framerate: br 1237704
...
[2025-05-30T20:42:47Z INFO  gst::webrtcsink] <basewebrtcsink0> doing dynamic resolution/framerate: br 1188195
```

When the property is disabled:
```
[2025-05-30T20:57:41Z INFO  gst::webrtcsink] <basewebrtcsink0> not doing dynamic resolution/framerate
...
[2025-05-30T20:57:42Z INFO  gst::webrtcsink] <basewebrtcsink0> not doing dynamic resolution/framerate
...
[2025-05-30T20:57:43Z INFO  gst::webrtcsink] <basewebrtcsink0> not doing dynamic resolution/framerate
...
[2025-05-30T20:57:44Z INFO  gst::webrtcsink] <basewebrtcsink0> not doing dynamic resolution/framerate
```

Note that this debug statement is not commited in the final code, but sits where one would expect it to be:
```
pub(crate) fn set_bitrate(
    &mut self,
    element: &super::BaseWebRTCSink,
    bitrate: i32,
) -> Result<(), WebRTCSinkError> {
    ...
    if element.property("do-dynamic-decimation") {
       // Added log here
    } else {
       // Added log here
    }
    ...
}
```
