### PR TITLE
Implement ParallelWebRTCSink plugin in gst-plugins-webrtc

### DIFF
--- a/net/webrtc/src/webrtcsink/imp.rs
+++ b/net/webrtc/src/webrtcsink/imp.rs
@@ -3250,7 +3250,7 @@ impl BaseWebRTCSink {
     }
 
     fn handle_sdp_answer(&self, session_id: &str, desc: &gst_webrtc::WebRTCSessionDescription) {
-        gst::warning!(CAT, imp = self, "Handling SDP answer for session {session_id}");
+        gst::info!(CAT, imp = self, "Handling SDP answer for session {session_id}");
         let mut state = self.state.lock().unwrap();
 
         if let Some(session) = state.sessions.get(session_id).map(|s| s.0.clone()) {
@@ -5253,8 +5253,6 @@ pub(super) mod parallel {
 
             // Return a promise to the call site since we cannot hold the lock here
             let promise = gst::Promise::with_change_func(glib::clone!(
-                // #[weak(rename_to = this)]
-                // self,
                 #[weak]
                 obj,
                 #[strong(rename_to = session_id)]
@@ -5362,7 +5360,6 @@ pub(super) mod parallel {
     impl ObjectImpl for PSWebRTCSink {
         fn constructed(&self) {
             let obj = self.obj();
-            gst::warning!(CAT, obj = obj, "constructing...");
             obj.set_suppressed_flags(gst::ElementFlags::SINK | gst::ElementFlags::SOURCE);
             obj.set_element_flags(gst::ElementFlags::SINK);
 

--- a/net/webrtc/src/webrtcsink/imp.rs
+++ b/net/webrtc/src/webrtcsink/imp.rs
@@ -4988,6 +4988,21 @@ pub(super) mod parallel {
             });
         }
 
+        /// When using a custom signaller
+        pub fn set_signaller(&self, signaller: Signallable) -> Result<(), Error> {
+            let sigobj = signaller.clone();
+
+            let obj = self.obj();
+            let baseclass = obj
+                .upcast_ref::<crate::webrtcsink::BaseWebRTCSink>()
+                .imp();
+            let mut settings = baseclass.settings.lock().unwrap();
+
+            self.connect_signaller(&sigobj);
+            settings.signaller = signaller;
+
+            Ok(())
+        }
 
         /// Called by the signaller to add a new session without the bells and whistles for video-related discovery.
         /// Sets the webrtcbin to `PLAYING` after instantiation and storing in session state.

--- a/net/webrtc/src/webrtcsink/imp.rs
+++ b/net/webrtc/src/webrtcsink/imp.rs
@@ -5064,6 +5064,7 @@ pub(super) mod parallel {
                 }
             }
 
+            // Critically, this pipeline only contains the `webrtcbin`. It doesn't do anything video-related.
             pipeline.add(&webrtcbin).unwrap();
 
             webrtcbin.connect_closure(

--- a/net/webrtc/src/webrtcsink/imp.rs
+++ b/net/webrtc/src/webrtcsink/imp.rs
@@ -4874,7 +4874,7 @@ pub(super) mod parallel {
                         move |_signaler: glib::Object, session_id: &str, peer_id: &str, offer: Option<&gst_webrtc::WebRTCSessionDescription>| {
                             if let Some(remote_offer) = offer {
                                 println!("Requesting session {session_id} peer {peer_id} from offer");
-                                if remote_offer.type_() != gst_webrtc::WebRTCSDPType::Answer {
+                                if remote_offer.type_() != gst_webrtc::WebRTCSDPType::Offer {
                                     gst::warning!(CAT, obj = this, "Invalid SDP type when requesting session");
                                     return;
                                 }

--- a/net/webrtc/src/webrtcsink/imp.rs
+++ b/net/webrtc/src/webrtcsink/imp.rs
@@ -4819,12 +4819,13 @@ pub(super) mod janus {
 
 pub(super) mod parallel {
     use super::*;
-
     #[derive(Default)]
     pub struct PSWebRTCSink {}
 
     impl PSWebRTCSink {
         fn connect_signaller(&self, signaller: &Signallable) {
+            println!("*** TESTING ***");
+
             let this = &*self.obj();
             let baseclass = this
                 .upcast_ref::<crate::webrtcsink::BaseWebRTCSink>()

--- a/net/webrtc/src/webrtcsink/imp.rs
+++ b/net/webrtc/src/webrtcsink/imp.rs
@@ -4824,7 +4824,7 @@ pub(super) mod parallel {
 
     impl PSWebRTCSink {
         fn connect_signaller(&self, signaller: &Signallable) {
-            println!("*** TESTING ***");
+            gst::warning!(CAT, obj = self.obj(), "Connecting to signaller");
 
             let this = &*self.obj();
             let baseclass = this
@@ -5348,6 +5348,7 @@ pub(super) mod parallel {
     impl ObjectImpl for PSWebRTCSink {
         fn constructed(&self) {
             let obj = self.obj();
+            gst::warning!(CAT, obj = obj, "constructing...");
             obj.set_suppressed_flags(gst::ElementFlags::SINK | gst::ElementFlags::SOURCE);
             obj.set_element_flags(gst::ElementFlags::SINK);
 

--- a/net/webrtc/src/webrtcsink/imp.rs
+++ b/net/webrtc/src/webrtcsink/imp.rs
@@ -4825,8 +4825,6 @@ pub(super) mod parallel {
 
     impl PSWebRTCSink {
         fn connect_signaller(&self, signaller: &Signallable) {
-            println!("Connecting to signaller");
-
             let this = &*self.obj();
             let baseclass = this
                 .upcast_ref::<crate::webrtcsink::BaseWebRTCSink>()
@@ -4873,25 +4871,21 @@ pub(super) mod parallel {
                         this,
                         move |_signaler: glib::Object, session_id: &str, peer_id: &str, offer: Option<&gst_webrtc::WebRTCSessionDescription>| {
                             if let Some(remote_offer) = offer {
-                                println!("Requesting session {session_id} peer {peer_id} from offer");
                                 if remote_offer.type_() != gst_webrtc::WebRTCSDPType::Offer {
                                     gst::warning!(CAT, obj = this, "Invalid SDP type when requesting session");
                                     return;
                                 }
 
-                                // gst::info!(CAT, obj = this, "Creating session {session_id} to remote {peer_id} with offer {remote_offer:?}");
-                                println!("Creating session {session_id} to remote {peer_id} with offer {remote_offer:?}");
+                                gst::info!(CAT, obj = this, "Creating session {session_id} to remote {peer_id} with offer {remote_offer:?}");
                                 if let Err(err) = this.imp().start_headless_session(session_id, peer_id) {
                                     gst::warning!(CAT, obj = this, "Unable to create offer-based session {session_id}/{peer_id}: {err}");
                                     return;
                                 };
 
-                                println!("Handling offer in session");
                                 let Ok((promise, webrtcbin)) = this.imp().handle_sdp_offer(session_id, remote_offer) else {
                                     gst::warning!(CAT, obj = this, "Unable to handle remote SDP offer");
                                     return;
                                 };
-                                println!("Creating answer through webrtcbin");
                                 webrtcbin.emit_by_name::<()>(
                                     "create-answer",
                                     &[&None::<gst::Structure>, &promise],

--- a/net/webrtc/src/webrtcsink/mod.rs
+++ b/net/webrtc/src/webrtcsink/mod.rs
@@ -73,6 +73,10 @@ glib::wrapper! {
     pub struct JanusVRWebRTCSink(ObjectSubclass<imp::janus::JanusVRWebRTCSink>) @extends BaseWebRTCSink, gst::Bin, gst::Element, gst::Object, @implements gst::ChildProxy, gst_video::Navigation;
 }
 
+glib::wrapper! {
+    pub struct ParallelWebRTCSink(ObjectSubclass<imp::parallel::PSWebRTCSink>) @extends BaseWebRTCSink, gst::Bin, gst::Element, gst::Object, @implements gst::ChildProxy, gst_video::Navigation;
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum WebRTCSinkError {
     #[error("no session with id")]
@@ -252,6 +256,13 @@ pub fn register(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
 
     #[cfg(feature = "janus")]
     JanusVRSignallerState::static_type().mark_as_plugin_api(gst::PluginAPIFlags::empty());
+
+    gst::Element::register(
+        Some(plugin),
+        "parallelwebrtcsink",
+        gst::Rank::NONE,
+        ParallelWebRTCSink::static_type(),
+    )?;
 
     Ok(())
 }

--- a/net/webrtc/src/webrtcsink/mod.rs
+++ b/net/webrtc/src/webrtcsink/mod.rs
@@ -116,6 +116,19 @@ impl BaseWebRTCSink {
     }
 }
 
+impl ParallelWebRTCSink {
+    pub fn with_signaller(signaller: Signallable) -> anyhow::Result<Self> {
+        let this: ParallelWebRTCSink = glib::Object::new();
+
+        let baseclass = this
+                .upcast_ref::<BaseWebRTCSink>()
+                .imp();
+        baseclass.set_signaller(signaller)?;
+
+        Ok(this)
+    }
+}
+
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy, glib::Enum)]
 #[repr(u32)]
 #[enum_type(name = "GstWebRTCSinkCongestionControl")]

--- a/net/webrtc/src/webrtcsink/mod.rs
+++ b/net/webrtc/src/webrtcsink/mod.rs
@@ -117,6 +117,7 @@ impl BaseWebRTCSink {
 }
 
 impl ParallelWebRTCSink {
+    /// Constructor for our `ParallelWebRTCSink` given a signaller.
     pub fn with_signaller(signaller: Signallable) -> anyhow::Result<Self> {
         let this: ParallelWebRTCSink = glib::Object::new();
 

--- a/net/webrtc/src/webrtcsink/mod.rs
+++ b/net/webrtc/src/webrtcsink/mod.rs
@@ -120,10 +120,8 @@ impl ParallelWebRTCSink {
     pub fn with_signaller(signaller: Signallable) -> anyhow::Result<Self> {
         let this: ParallelWebRTCSink = glib::Object::new();
 
-        let baseclass = this
-                .upcast_ref::<BaseWebRTCSink>()
-                .imp();
-        baseclass.set_signaller(signaller)?;
+        let imp = this.imp();
+        imp.set_signaller(signaller)?;
 
         Ok(this)
     }


### PR DESCRIPTION
# Background
We want a WebRTC plugin that can accommodate negotiating sessions to both Video and Text Room Janus plugins. Critically, the latter kind of session doesn't involve any video, only data channels.

# Description
 The BaseWebRTCSink implementation is heavily tied to local-offer-based SDP negotiation, wherein the plugin runs a codec discovery pipeline to determine the media capabilities of the host it's running on. This is great for a plug-and-play video solution, but we want to also operate sessions that don't contain any video, and simply transmit data.

This PR adds a `PsWebRTCSink` plugin to the `gst-plugin-webrtc` crate that subclasses from `BaseWebRTCSink` that accomplishes that, by differentiating behavior when presented with a remote SDP offer on session construction. On `session-requested`, if `offer` is `Some` and it's an `gst_webrtc::WebRTCSDPType::Offer` type, the `PsWebRTCSink` constructs a "headless session" - which purely sets up a peer connection based on the remote offer.
The flow was inspired by that in `WebRTCSrc`, which more directly implements an offer-based session negotiation without running the local codec discovery seen on the `BaseWebRTCSink`. Here, we use a `gst::Promise` in conjunction with the `webrtcbin`'s `create-answer` signal to set the remote SDP offer and asynchronously create an answer.
Finally, when the headless session is created, we emit signals for data channel creation that allow the parent application/bin to setup a data channel and store it in the session state.

# Verification
Extensive local testing
